### PR TITLE
Add support for ADV OKOK Scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 ## Introduction
 
 Home Assistant integration to read Bluetooth scales which can be used with the *OKOK international*
-app and identify themselves on Bluetooth as *Chipsea-BLE*.
+app and identify themselves on Bluetooth as *Chipsea-BLE* or *ADV*.
 
 ## Features
 
@@ -28,6 +28,7 @@ app and identify themselves on Bluetooth as *Chipsea-BLE*.
 The following scale is known to work:
 
 * Tristar WG-2440
+* Taffware SH-Y01-U1
 
 Please let me know if your scale works with this Home Assistant integration so I can
 improve the overview of supported scales.

--- a/custom_components/okokscale/manifest.json
+++ b/custom_components/okokscale/manifest.json
@@ -2,7 +2,8 @@
   "domain": "okokscale",
   "name": "OKOK Scale",
   "bluetooth": [
-  	{ "local_name": "Chipsea-BLE" }
+    { "local_name": "Chipsea-BLE" },
+    { "local_name": "ADV", "manufacturer_id": 8394 }
   ],
   "codeowners": [
     "@rrooggiieerr"

--- a/custom_components/okokscale/okokscale.py
+++ b/custom_components/okokscale/okokscale.py
@@ -270,8 +270,17 @@ class OKOKScaleBluetoothDeviceData(BluetoothData):
             _LOGGER.debug("manufacturer_data: %s", data.hex())
             if data is None or len(data) != 19:
                 return
+            _LOGGER.debug(
+                "v20 bytes: %s",
+                " ".join(f"{b:02x}" for b in data),
+            )
+            _LOGGER.debug("v20 flags: final=0x%02x", data[IDX_V20_FINAL])
 
             if (data[IDX_V20_FINAL] & 1) == 0:
+                _LOGGER.debug(
+                    "v20 not final; skipping weight/impedance. "
+                    "If this is your scale, capture a few samples with a known weight."
+                )
                 return
 
             checksum = 0x20  # Version field is part of the checksum, but not in array

--- a/custom_components/okokscale/okokscale.py
+++ b/custom_components/okokscale/okokscale.py
@@ -89,7 +89,14 @@ class OKOKScaleBluetoothDeviceData(BluetoothData):
 
     def _start_update(self, service_info: BluetoothServiceInfo) -> None:
         """Update from BLE advertisement data."""
-        if service_info.name not in ["Chipsea-BLE"]:
+        if service_info.name not in ["Chipsea-BLE", "ADV"]:
+            return
+        if 8394 not in service_info.manufacturer_data:
+            _LOGGER.debug(
+                "Manufacturer id 0x20CA (8394) not found for %s; ids=%s",
+                service_info.address,
+                list(service_info.manufacturer_data.keys()),
+            )
             return
 
         self.log_service_info(service_info)

--- a/custom_components/okokscale/sensor.py
+++ b/custom_components/okokscale/sensor.py
@@ -64,17 +64,18 @@ def sensor_update_to_bluetooth_data_update(
     sensor_update: SensorUpdate,
 ) -> PassiveBluetoothDataUpdate:
     """Convert a sensor update to a bluetooth data update."""
+    entity_descriptions = {}
+    for device_key in sensor_update.entity_descriptions:
+        description = SENSOR_DESCRIPTIONS.get(device_key.key)
+        if description is None:
+            continue
+        entity_descriptions[device_key_to_bluetooth_entity_key(device_key)] = description
     return PassiveBluetoothDataUpdate(
         devices={
             device_id: sensor_device_info_to_hass_device_info(device_info)
             for device_id, device_info in sensor_update.devices.items()
         },
-        entity_descriptions={
-            device_key_to_bluetooth_entity_key(device_key): SENSOR_DESCRIPTIONS[
-                device_key.key
-            ]
-            for device_key in sensor_update.entity_descriptions
-        },
+        entity_descriptions=entity_descriptions,
         entity_data={
             device_key_to_bluetooth_entity_key(device_key): sensor_values.native_value
             for device_key, sensor_values in sensor_update.entity_values.items()

--- a/custom_components/okokscale/sensor.py
+++ b/custom_components/okokscale/sensor.py
@@ -51,6 +51,12 @@ SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
         state_class=SensorStateClass.MEASUREMENT,
         translation_key=OKOKScaleSensor.BATTERY_PERCENT,
     ),
+    OKOKScaleSensor.IMPEDANCE: SensorEntityDescription(
+        key=OKOKScaleSensor.IMPEDANCE,
+        native_unit_of_measurement="Ω",
+        state_class=SensorStateClass.MEASUREMENT,
+        translation_key=OKOKScaleSensor.IMPEDANCE,
+    ),
 }
 
 


### PR DESCRIPTION
I have super cheap OEM OKOK Scale with BT name "ADV", and manufacturer_id is 8394.
- It does not have v20 checksum so i did change logic on okokscale.py only for adv device.
- ADV sensor also do not have impedance, so i change little logic for safe get impedance sensor.
- By default, when done scaling, ADV sending ghost values (may be 0.2, or 0.9, or 1.3, etc) which causing entity randomly set to 0,0 Kg. So i added minimum weight to 2.0 Kg for prevent HA entity got reset.

Logs raw bluetooth data:
```
2026-02-10 19:14:25.665 DEBUG (MainThread) [homeassistant.components.bluetooth.manager] hci0 (8C:88:2B:41:B0:45) [connectable]: <BluetoothServiceInfoBleak name=ADV address=ED:67:37:A1:A8:73 rssi=-82 manufacturer_data={8394: b'\x0bA\xaf/\x81\x01\x04\x02\x14\xbe\x00\x00\xc6\xedg7\xa1\xa8s'} service_data={} service_uuids=[] source=8C:88:2B:41:B0:45 connectable=True time=164273.779120948 tx_power=None raw=b'\x02\x01\x04\x04\tADV\x16\xff\xca \x0bA\xaf/\x81\x01\x04\x02\x14\xbe\x00\x00\xc6\xedg7\xa1\xa8s'> match: set()
2026-02-10 19:14:34.448 DEBUG (MainThread) [homeassistant.components.bluetooth.manager] hci0 (8C:88:2B:41:B0:45) [connectable]: <BluetoothServiceInfoBleak name=ADV address=ED:67:37:A1:A8:73 rssi=-86 manufacturer_data={8394: b'\x0bA\xaf/\x81\x01\x05\x1b\x14\xbe\x17p\xb9\xedg7\xa1\xa8s'} service_data={} service_uuids=[] source=8C:88:2B:41:B0:45 connectable=True time=164282.56193939 tx_power=None raw=b'\x02\x01\x04\x04\tADV\x16\xff\xca \x0bA\xaf/\x81\x01\x05\x1b\x14\xbe\x17p\xb9\xedg7\xa1\xa8s'> match: set()
2026-02-10 19:14:44.491 DEBUG (MainThread) [homeassistant.components.bluetooth.manager] hci0 (8C:88:2B:41:B0:45) [connectable]: <BluetoothServiceInfoBleak name=ADV address=ED:67:37:A1:A8:73 rssi=-84 manufacturer_data={8394: b'\x0bA\xaf/\x81\x01\x04g\x00\x00\x00\x00\t\xedg7\xa1\xa8s'} service_data={} service_uuids=[] source=8C:88:2B:41:B0:45 connectable=True time=164292.604732828 tx_power=None raw=b'\x02\x01\x04\x04\tADV\x16\xff\xca \x0bA\xaf/\x81\x01\x04g\x00\x00\x00\x00\t\xedg7\xa1\xa8s'> match: set()
```

Tested and working fine on mine. By the way, is "Signal Strength" unused and always disabled?
